### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,14 @@ COPY . .
 
 # install all depedencies
 RUN chmod +x ./install.sh
-RUN apt -y update && apt -y install git  	\
-				    wget 	\
-				    python3 	\
-				    python3-pip
+RUN apt-get -y update && apt-get -y install --no-install-recommends \
+    git         \
+    wget 	\
+    python3 	\
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /usr/share/doc && rm -rf /usr/share/man \
+    && apt-get clean
 RUN ./install.sh
 ENV HOME /root
 ENV GOPATH=$HOME/go/bin


### PR DESCRIPTION
1. `--no-install-recommends`
2. `apt` is for end-user to use, Dockerfiles should use `apt-get`
3. `/var/lib/apt/lists/*` should be removed to reduce the image size
4. `/usr/share/doc` && `/usr/share/man` are most probably not going to be used in a container, better to be removed.
5. `apt-get clean` clears out the local repository of retrieved package files. It removes everything but the lock file from `/var/cache/apt/archives/` and `/var/cache/apt/archives/partial/`.

